### PR TITLE
Trim left zero from expected value

### DIFF
--- a/crates/ibc/src/client_state.rs
+++ b/crates/ibc/src/client_state.rs
@@ -989,4 +989,15 @@ mod tests {
             panic!("expected error");
         }
     }
+
+    #[test]
+    fn test_trim_left_zero() {
+        assert_eq!(trim_left_zero(&[1, 2, 3, 4]), [1, 2, 3, 4]);
+        assert_eq!(trim_left_zero(&[1, 2, 3, 0]), [1, 2, 3, 0]);
+        assert_eq!(trim_left_zero(&[0, 2, 3, 0]), [2, 3, 0]);
+        assert_eq!(trim_left_zero(&[0, 0, 3, 0]), [3, 0]);
+        assert_eq!(trim_left_zero(&[0, 0, 0, 4]), [4]);
+        assert!(trim_left_zero(&[0, 0, 0, 0]).is_empty());
+        assert!(trim_left_zero(&[]).is_empty());
+    }
 }

--- a/crates/ibc/src/client_state.rs
+++ b/crates/ibc/src/client_state.rs
@@ -123,7 +123,7 @@ impl<const SYNC_COMMITTEE_SIZE: usize, const EXECUTION_PAYLOAD_TREE_DEPTH: usize
             .verify_membership(
                 H256::from_slice(root.as_bytes()),
                 key.as_bytes(),
-                rlp::encode(&value).as_ref(),
+                rlp::encode(&trim_left_zero(&value)).as_ref(),
                 proof.clone(),
             )
             .map_err(|e| ClientError::ClientSpecific {
@@ -822,6 +822,17 @@ fn maybe_consensus_state(
             }),
         },
     }
+}
+
+fn trim_left_zero(value: &[u8]) -> &[u8] {
+    let mut pos = 0;
+    for v in value {
+        if *v != 0 {
+            break;
+        }
+        pos += 1;
+    }
+    &value[pos..]
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Since the left zeros are trimmed in MPT, it is necessary to trim the left zeros for verification.

https://github.com/ethereum/go-ethereum/blob/93c541ad563124e81d125c7ebe78938175229b2e/core/state/state_object.go#L318

https://github.com/ethereum/go-ethereum/blob/93c541ad563124e81d125c7ebe78938175229b2e/internal/ethapi/api.go#L740

